### PR TITLE
Removed lozenges and placeholders

### DIFF
--- a/_data/sidebars/overview_sidebar.yml
+++ b/_data/sidebars/overview_sidebar.yml
@@ -1,7 +1,7 @@
 entries:
 - title: FHIR&reg; ODS Lookup API
   product: FHIR&reg; ODS Lookup API
-  version: 1.0.0-Live
+  version: 1.1.1-Live
   levels: one
   folders:
 
@@ -85,26 +85,26 @@ entries:
             url: /build_organization_search.html
             output: web
 
-  - title: Test
-    output: web
-    folderitems:
-    - title: Overview
-      url: /test.html
-      output: web
+#  - title: Test
+#    output: web
+#    folderitems:
+#    - title: Overview
+#      url: /test.html
+#      output: web
  
-  - title: Assure
-    output: web
-    folderitems:
-    - title: Overview
-      url: /assure.html
-      output: web
+#  - title: Assure
+#    output: web
+#    folderitems:
+#    - title: Overview
+#      url: /assure.html
+#      output: web
 
-  - title: Deploy
-    output: web
-    folderitems:
-    - title: Overview
-      url: /deploy.html
-      output: web
+#  - title: Deploy
+#    output: web
+#    folderitems:
+#    - title: Overview
+#      url: /deploy.html
+#      output: web
 
   - title: Help & Support
     output: web

--- a/index.md
+++ b/index.md
@@ -20,10 +20,3 @@ The endpoint for the ODS Lookup API is:
 https://directory.spineservices.nhs.uk/STU3/</div>
 
 
-# Using this guide #
-
-This guide has been created to support the adoption of the FHIR&reg; ODS Lookup API profiles and FHIR resources. As such the site is structured around stakeholders including API users, developers and architects, who have an interest in implementing the FHIR&reg; ODS Lookup API.  
-
-{% include custom/api_overview.svg %}
-
-

--- a/pages/explore/explore.md
+++ b/pages/explore/explore.md
@@ -7,8 +7,6 @@ permalink: explore.html
 summary: "Overview of the Resources section"
 ---
 
-{% include custom/api_overview.svg %}
-
 ## 1. Resource API Structure ##
 
 The FHIR ODS Lookup profile API described in this section of the Implementation Guide has been structured consistently in the following way:

--- a/pages/overview/overview_release_notes.md
+++ b/pages/overview/overview_release_notes.md
@@ -7,15 +7,18 @@ permalink: overview_release_notes.html
 summary: Summary release notes of the FHIR&reg; ODS Lookup API Implementation Guide
 ---
 
+## 1.1.1-Live ##
+
+- Removed unnecessary placeholder sections from site
+
+## 1.1.0-Live ##
+
+- Amendment to error handling
+
 ## 1.0.0-Live ##
 
 Implementation Guide uplifted to Live status
 - Removal of development banners and warnings
-
-## 1.1.0-beta ##
-
-- Amendment to error handling
-
 
 ## 1.0.0-beta ##
 


### PR DESCRIPTION
I've removed the image with the development stages as everything it pointed to were placeholders, which didn't look great. We can reinstate later if we have content to back it up. I also removed the sections from the nav which only had placeholders in them for the same reason, and upversioned to 1.1.1.